### PR TITLE
Fix bug when moving a window to the current workspace

### DIFF
--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -168,9 +168,9 @@ The optional FORCE option is for internal use only."
   (unless id (setq id (exwm--buffer->id (window-buffer))))
   (unless (and (<= 0 index) (< index exwm-workspace-number))
     (user-error "[EXWM] Workspace index out of range: %d" index))
-  (when (/= exwm-workspace-current-index index)
+  (with-current-buffer (exwm--id->buffer id)
     (let ((frame (elt exwm-workspace--list index)))
-      (with-current-buffer (exwm--id->buffer id)
+      (when (not (equal exwm--frame frame))
         (setq exwm--frame frame)
         (exwm-workspace-rename-buffer
          (concat " " (replace-regexp-in-string "^\\s-*" "" (buffer-name))))

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -171,9 +171,11 @@ The optional FORCE option is for internal use only."
   (with-current-buffer (exwm--id->buffer id)
     (let ((frame (elt exwm-workspace--list index)))
       (when (not (equal exwm--frame frame))
+        (let ((name (replace-regexp-in-string "^\\s-*" "" (buffer-name))))
+          (exwm-workspace-rename-buffer (if (= index exwm-workspace-current-index)
+                                            name
+                                          (concat " " name))))
         (setq exwm--frame frame)
-        (exwm-workspace-rename-buffer
-         (concat " " (replace-regexp-in-string "^\\s-*" "" (buffer-name))))
         (if exwm--floating-frame
             ;; Move the floating frame is enough
             (progn


### PR DESCRIPTION
	* exwm-workspace.el (exwm-workspace-move-window): Run
          reparenting code when moving a window to the current workspace.

Hi! I think I've found a small bug when moving a window that's on another workspace to the current workspace with exwm-workspace-move-window: the test

    (when (/= exwm-workspace-current-index index)

was probably intended to test whether the window's current frame is changing, not whether we're currently on the workspace the window is moving to.