### PR TITLE
Robustness

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -93,6 +93,8 @@
   "Make window ID fullscreen."
   (interactive)
   (with-current-buffer (if id (exwm--id->buffer id) (window-buffer))
+    (when exwm--fullscreen
+      (user-error "Already in full-screen mode."))
     ;; Set the floating frame fullscreen first when the client is floating
     (when exwm--floating-frame
       (let* ((outer-id (frame-parameter exwm--floating-frame 'exwm-outer-id))
@@ -130,7 +132,6 @@
                        :window exwm--id
                        :data (vector xcb:Atom:_NET_WM_STATE_FULLSCREEN)))
     (xcb:flush exwm--connection)
-    (cl-assert (not exwm--fullscreen))
     (setq exwm--fullscreen t)
     (exwm-input-release-keyboard)))
 
@@ -138,6 +139,8 @@
   "Restore window from fullscreen state."
   (interactive)
   (with-current-buffer (if id (exwm--id->buffer id) (window-buffer))
+    (unless exwm--fullscreen
+      (user-error "Not in full-screen mode."))
     ;; Restore the floating frame if the client is floating
     (when exwm--floating-frame
       (xcb:+request exwm--connection
@@ -156,7 +159,6 @@
     (xcb:+request exwm--connection
         (make-instance 'xcb:ewmh:set-_NET_WM_STATE :window exwm--id :data []))
     (xcb:flush exwm--connection)
-    (cl-assert exwm--fullscreen)
     (setq exwm--fullscreen nil)
     (exwm-input-grab-keyboard)))
 

--- a/exwm-manage.el
+++ b/exwm-manage.el
@@ -260,10 +260,9 @@ corresponding buffer.")
   "Kill an X client."
   (interactive)
   (unless id (setq id (exwm--buffer->id (current-buffer))))
-  (let ((pid (slot-value
-              (xcb:+request-unchecked+reply exwm--connection
-                  (make-instance 'xcb:ewmh:get-_NET_WM_PID :window id))
-              'value)))
+  (let* ((response (xcb:+request-unchecked+reply exwm--connection
+                       (make-instance 'xcb:ewmh:get-_NET_WM_PID :window id)))
+         (pid (and response (slot-value response 'value))))
     (if pid
         (signal-process pid 'SIGKILL)
       (xcb:+request exwm--connection


### PR DESCRIPTION
Hi,
I've been working on support for multiple top-level frames visible at the same time (since each of those frames has its own minibuffer, this effectively allows us to use the minibuffer space when running a client in one of those frames); I'll push my work to my master branch when I'm done with the PRs.

Anyway, it's happened to me a few times that functions signalled hard errors and broke things, so I think it's in the interest of code robustness to be a bit more lenient when we get unknown arguments.

For example, when killing clients, we would throw an error if the client had already died in the meantime; or, when using the interactive commands to set a client to full-screen mode, exwm-input--release-keyboard will be called with an invalid argument and the error breaks things.

So I think these changes would be a better idea than hunting down all callers that might supply incomplete arguments.