### PR TITLE
Avoid using the "no window manager" code in Emacs

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -162,6 +162,34 @@
     (setq exwm--fullscreen nil)
     (exwm-input-grab-keyboard)))
 
+;; This function is superficially similar to `exwm-layout-set-fullscreen', but
+;; they do very different things: `exwm-layout--set-frame-fullscreen' resizes a
+;; frame to the actual monitor size, `exwm-layout-set-fullscreen' resizes an X
+;; window to the frame size.
+(defun exwm-layout--set-frame-fullscreen (frame)
+  "Make frame FRAME fullscreen, with regard to its XRandR output if applicable."
+  (let ((geometry (or (frame-parameter frame 'exwm-geometry)
+                      (xcb:+request-unchecked+reply
+                          exwm--connection
+                          (make-instance 'xcb:GetGeometry
+                                         :drawable exwm--root))
+                      (make-instance 'xcb:RECTANGLE :x 0 :y 0
+                                     :width (x-display-width)
+                                     :height (x-display-height))))
+         (id (frame-parameter frame 'exwm-outer-id)))
+    (with-slots (x y width height) geometry
+                (xcb:+request exwm--connection
+                    (make-instance 'xcb:ConfigureWindow
+                                   :window id
+                                   :value-mask (logior xcb:ConfigWindow:X
+                                                       xcb:ConfigWindow:Y
+                                                       xcb:ConfigWindow:Width
+                                                       xcb:ConfigWindow:Height)
+                                   :x x :y y
+                                   :width width
+                                   :height height))
+                (xcb:flush exwm--connection))))
+
 (defun exwm-layout--refresh ()
   "Refresh layout."
   (let ((frame (selected-frame))

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -85,6 +85,12 @@
           (setq geometry default-geometry
                 output nil))
         (set-frame-parameter frame 'exwm-randr-output output)
+        (set-frame-parameter frame 'exwm-geometry
+                             (make-instance 'xcb:RECTANGLE
+                                            :x (elt geometry 0)
+                                            :y (elt geometry 1)
+                                            :width (elt geometry 2)
+                                            :height (elt geometry 3)))
         (set-frame-parameter frame 'exwm-x (elt geometry 0))
         (set-frame-parameter frame 'exwm-y (elt geometry 1))
         (xcb:+request exwm--connection


### PR DESCRIPTION
This is as discussed on #39, I think. I'm using xcb:RECTANGLE as a geometry type rather than a vector; do let me know if you prefer using an [x y width height] vector and I'll change the code.

There's also some code to support horizontal/vertical resizing that needs some explanation: my setup is to have two "workspace" frames side-by-side, so I would set `keep-x`; however, in order to inhibit width changes when setting the font, I'd still like the fullscreen property to be fullboth.

        * exwm.el (exwm--on-ClientMessage): Handle fullscreen requests
	for frames.
	(exwm-init): Initialize workspaces after unlocking events.

	* exwm-workspace.el (exwm-workspace--init): Create frames as
	invisible, then make them visible only once their OverrideRedirect
	property has been set.

	* exwm-randr.el (exwm-randr--refresh): New frame parameter
	`exwm-geometry'.

	* exwm-layout.el (exwm-layout--fullscreen-geometry): New function.
	(exwm-layout--set-frame-fullscreen): New function.

The Emacs code is buggy, see https://github.com/ch11ng/exwm/issues/39