### PR TITLE
Warp mouse pointer only when necessary.

### DIFF
--- a/exwm-floating.el
+++ b/exwm-floating.el
@@ -258,7 +258,7 @@
       (with-slots (root-x root-y win-x win-y)
           (xcb:+request-unchecked+reply exwm--connection
               (make-instance 'xcb:QueryPointer :window id))
-        (select-frame-set-input-focus frame) ;raise and focus it
+        (exwm-workspace--select-frame frame)
         (setq width (frame-pixel-width frame)
               height (frame-pixel-height frame))
         (unless type

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -117,13 +117,12 @@ It's updated in several occasions, and only used by `exwm-input--set-focus'.")
           (progn
             (when exwm--floating-frame
               (redirect-frame-focus exwm--floating-frame nil)
-              (select-frame-set-input-focus exwm--floating-frame t))
+              (exwm-workspace--select-frame exwm--floating-frame t))
             (exwm--log "Set focus on #x%x" exwm--id)
             (exwm-input--set-focus exwm--id))
         (when (eq (selected-window) exwm-input--focus-window)
           (exwm--log "Focus on %s" exwm-input--focus-window)
-          (select-frame-set-input-focus (window-frame exwm-input--focus-window)
-                                        t)
+          (exwm-workspace--select-frame (window-frame exwm-input--focus-window) t)
           (dolist (pair exwm--id-buffer-alist)
             (with-current-buffer (cdr pair)
               (when (and exwm--floating-frame

--- a/exwm.el
+++ b/exwm.el
@@ -187,10 +187,6 @@
                                          xcb:EventMask:SubstructureRedirect)))
   (xcb:flush exwm--connection))
 
-(defun exwm--make-emacs-idle-for (seconds)
-  "Put Emacs in idle state for SECONDS seconds."
-  (with-timeout (seconds) (read-event)))
-
 (defun exwm-reset ()
   "Reset window to standard state: non-fullscreen, line-mode."
   (interactive)


### PR DESCRIPTION
See https://github.com/ch11ng/exwm/issues/39

Feel free to leave this open until you can test on XRandR, of course, there might have been another problem I haven't thought of.

This version checks the mouse pointer's absolute position is over the frame, not whether its 