### PR TITLE
Use pre-redisplay-function to detect mini-window resizes.

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -189,8 +189,8 @@
                          :height height))
       (xcb:flush exwm--connection))))
 
-(defun exwm-layout--refresh ()
-  "Refresh layout."
+(defun exwm-layout--refresh (&rest args)
+  "Refresh layout.  ARGS are ignored to run in abnormal hooks."
   (let ((frame (selected-frame))
         (placeholder (get-buffer "*scratch*"))
         windows)
@@ -236,21 +236,13 @@
                      (or exwm--floating-frame (not (eq frame exwm--frame))))
             (set-window-buffer window placeholder)))))))
 
-(defun exwm-layout--on-minibuffer-setup ()
-  "Refresh layout when minibuffer grows."
-  (run-with-idle-timer 0.01 nil         ;FIXME
-                       (lambda ()
-                         (when (and (< 1 (window-height (minibuffer-window)))
-                                    (not (and (eq major-mode 'exwm-mode)
-                                              exwm--floating-frame)))
-                           (exwm-layout--refresh)))))
-
 (defun exwm-layout--init ()
   "Initialize layout module."
   ;; Auto refresh layout
   (add-hook 'window-configuration-change-hook 'exwm-layout--refresh)
-  ;; Refresh when minibuffer grows
-  (add-hook 'minibuffer-setup-hook 'exwm-layout--on-minibuffer-setup t))
+  ;; Refresh when minibuffer grows, if Emacs is new enough to detect it
+  (when (boundp 'pre-redisplay-function)
+    (add-function :before pre-redisplay-function 'exwm-layout--refresh)))
 
 
 


### PR DESCRIPTION
Fixes https://github.com/ch11ng/exwm/issues/40

See http://debbugs.gnu.org/cgi/bugreport.cgi?bug=21333

Do let me know what needs changing. In particular, do you prefer a simple wrapper around `exwm-layout--refresh` to making it accept and ignore arguments?

I'd also like to thank you for your cooperation in general and the xterm fix in particular. I confess I never previously understood how XAllowEvents worked!

(I'd originally rewritten much more of the code in exwm-layout.el, but I never really got that to work the way it should.)