### PR TITLE
Dynamic workspaces

### DIFF
--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -76,7 +76,7 @@
               (unless default-geometry ;assume the first output as primary
                 (setq default-geometry geometry)))))))
     (cl-assert (<= 2 (length output-plist)))
-    (dotimes (i (length exwm-workspace--list))
+    (dotimes (i (exwm-workspace--count))
       (let* ((output (plist-get exwm-randr-workspace-output-plist i))
              (geometry (lax-plist-get output-plist output))
              (frame (elt exwm-workspace--list i)))

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -76,7 +76,7 @@
               (unless default-geometry ;assume the first output as primary
                 (setq default-geometry geometry)))))))
     (cl-assert (<= 2 (length output-plist)))
-    (dotimes (i exwm-workspace-number)
+    (dotimes (i (length exwm-workspace--list))
       (let* ((output (plist-get exwm-randr-workspace-output-plist i))
              (geometry (lax-plist-get output-plist output))
              (frame (elt exwm-workspace--list i)))

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -292,6 +292,26 @@ The optional FORCE option is for internal use only."
                                        (lambda (i)
                                          (frame-parameter i 'exwm-window-id))
                                        exwm-workspace--list))))
+    ;; Set _NET_NUMBER_OF_DESKTOPS
+    (xcb:+request exwm--connection
+        (make-instance 'xcb:ewmh:set-_NET_NUMBER_OF_DESKTOPS
+                       :window exwm--root
+                       :data num-workspaces))
+    ;; Set _NET_DESKTOP_VIEWPORT
+    (xcb:+request exwm--connection
+        (make-instance 'xcb:ewmh:set-_NET_DESKTOP_VIEWPORT
+                       :window exwm--root
+                       :data (make-vector (* 2 num-workspaces) 0)))
+
+    ;; Set _NET_WORKAREA (with minibuffer and bottom mode-line excluded)
+    (let* ((workareas
+            (vector 0 0 (x-display-pixel-width) (x-display-pixel-height)))
+           (workareas (mapconcat (lambda (i) workareas)
+                                 (make-list num-workspaces 0) [])))
+      (xcb:+request exwm--connection
+          (make-instance 'xcb:ewmh:set-_NET_WORKAREA
+                         :window exwm--root
+                         :data workareas)))
     (xcb:flush exwm--connection)))
 
 (defun exwm-workspace--init ()

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -293,19 +293,22 @@ The optional FORCE option is for internal use only."
             (x (yes-or-no-p (format "[EXWM] %d window%s currently alive. %s"
                                     x (if (= x 1) "" "s") prompt))))))
   ;; Initialize workspaces
-  (setq exwm-workspace--list (frame-list))
-  (when (< 1 (exwm-workspace--count))
-    ;; Emacs client creates an extra (but unusable) frame
-    (dolist (i exwm-workspace--list)
-      (unless (frame-parameter i 'window-id)
-        (setq exwm-workspace--list (delq i exwm-workspace--list))))
-    (cl-assert (= 1 (exwm-workspace--count)))
-    ;; Prevent user from deleting this frame by accident
-    (set-frame-parameter (car exwm-workspace--list) 'client nil))
-  ;; Configure workspaces
-  (dolist (i exwm-workspace--list)
-    (exwm-workspace--add-frame-as-workspace i))
-  (select-frame-set-input-focus (car exwm-workspace--list))
+  (let ((initial-workspaces (frame-list)))
+    (when (< 1 (length initial-workspaces))
+      ;; Emacs client creates an extra (but unusable) frame
+      (dolist (i initial-workspaces)
+        (unless (frame-parameter i 'window-id)
+          (setq initial-workspaces (delq i initial-workspaces))))
+      (cl-assert (= 1 (exwm-workspace--count)))
+      ;; Prevent user from deleting this frame by accident
+      (set-frame-parameter (car initial-workspaces) 'client nil))
+    ;; TODO: this prevents user having a creating initial workspaces by making
+    ;;       frames in their configuration before launching EXWM.
+    (cl-assert (= 1 (length initial-workspaces)))
+    ;; Configure workspaces
+    (dolist (i initial-workspaces)
+      (exwm-workspace--add-frame-as-workspace i))
+    (select-frame-set-input-focus (car initial-workspaces)))
   ;; Handle unexpected frame switch
   (add-hook 'focus-in-hook 'exwm-workspace--on-focus-in)
   ;; Make new frames create new workspaces.

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -362,12 +362,8 @@ The optional FORCE option is for internal use only."
       (dolist (i initial-workspaces)
         (unless (frame-parameter i 'window-id)
           (setq initial-workspaces (delq i initial-workspaces))))
-      (cl-assert (= 1 (exwm-workspace--count)))
-      ;; Prevent user from deleting this frame by accident
+      ;; Prevent user from deleting the first frame by accident
       (set-frame-parameter (car initial-workspaces) 'client nil))
-    ;; TODO: this prevents user having a creating initial workspaces by making
-    ;;       frames in their configuration before launching EXWM.
-    (cl-assert (= 1 (length initial-workspaces)))
     ;; Configure workspaces
     (dolist (i initial-workspaces)
       (exwm-workspace--add-frame-as-workspace i))

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -257,6 +257,11 @@ The optional FORCE option is for internal use only."
   (cond
    ((memq frame exwm-workspace--list)
     (exwm--log "Frame is already a workspace: %s" frame))
+   ((not (display-graphic-p frame))
+    (exwm--log "Frame is not graphical: %s" frame))
+   ((not (eq (slot-value exwm--connection 'display)
+             (frame-parameter frame 'display)))
+    (exwm--log "Frame is on a different DISPLAY: %s" frame))
    (t
     (exwm--log "Adding workspace: %s" frame)
     (setq exwm-workspace--list (nconc exwm-workspace--list (list frame)))

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -302,11 +302,6 @@ The optional FORCE option is for internal use only."
     (cl-assert (= 1 (exwm-workspace--count)))
     ;; Prevent user from deleting this frame by accident
     (set-frame-parameter (car exwm-workspace--list) 'client nil))
-  ;; Create remaining frames
-  (dotimes (i (1- exwm-workspace-number))
-    (nconc exwm-workspace--list
-           (list (make-frame '((window-system . x)
-                               (visibility . nil))))))
   ;; Configure workspaces
   (dolist (i exwm-workspace--list)
     (exwm-workspace--add-frame-as-workspace i))

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -26,7 +26,7 @@
 
 ;;; Code:
 
-(defvar exwm-workspace-number 4 "Number of workspaces (1 ~ 10).")
+(defvar exwm-workspace-max-count 10 "Maximum number of workspaces.")
 (defvar exwm-workspace--list nil "List of all workspaces (Emacs frames).")
 
 (defun exwm-workspace--count ()
@@ -40,7 +40,7 @@
       (define-key map (int-to-string i)
         `(lambda ()
            (interactive)
-           (when (< ,i exwm-workspace-number)
+           (when (< ,i exwm-workspace-max-count)
              (goto-history-element ,(1+ i))
              (exit-minibuffer)))))
     (define-key map "\C-a" (lambda () (interactive) (goto-history-element 1)))
@@ -220,9 +220,9 @@ The optional FORCE option is for internal use only."
 (defun exwm-workspace--add-frame-as-workspace (frame)
   "Configure frame FRAME to be treated as a workspace."
   (cond
-   ((>= (exwm-workspace--count) exwm-workspace-number)
+   ((>= (exwm-workspace--count) exwm-workspace-max-count)
     (delete-frame frame)
-    (user-error "[EXWM] Too many workspaces: maximum is %d" exwm-workspace-number))
+    (user-error "[EXWM] Too many workspaces: maximum is %d" exwm-workspace-max-count))
    ((memq frame exwm-workspace--list)
     (exwm--log "Frame is already a workspace: %s" frame))
    (t
@@ -284,7 +284,7 @@ The optional FORCE option is for internal use only."
 
 (defun exwm-workspace--init ()
   "Initialize workspace module."
-  (cl-assert (and (< 0 exwm-workspace-number) (>= 10 exwm-workspace-number)))
+  (cl-assert (and (< 0 exwm-workspace-max-count) (>= 10 exwm-workspace-max-count)))
   ;; Prevent unexpected exit
   (setq confirm-kill-emacs
         (lambda (prompt)

--- a/exwm.el
+++ b/exwm.el
@@ -568,23 +568,6 @@
       (xcb:+request exwm--connection
           (make-instance 'xcb:ewmh:set-_NET_WM_NAME
                          :window i :data "EXWM"))))
-  ;; Set _NET_NUMBER_OF_DESKTOPS
-  (xcb:+request exwm--connection
-      (make-instance 'xcb:ewmh:set-_NET_NUMBER_OF_DESKTOPS
-                     :window exwm--root :data exwm-workspace-max-count))
-  ;; Set _NET_DESKTOP_VIEWPORT
-  (xcb:+request exwm--connection
-      (make-instance 'xcb:ewmh:set-_NET_DESKTOP_VIEWPORT
-                     :window exwm--root
-                     :data (make-vector (* 2 exwm-workspace-max-count) 0)))
-  ;; Set _NET_WORKAREA (with minibuffer and bottom mode-line excluded)
-  (let* ((workareas
-          (vector 0 0 (x-display-pixel-width) (x-display-pixel-height)))
-         (workareas (mapconcat (lambda (i) workareas)
-                               (make-list exwm-workspace-max-count 0) [])))
-    (xcb:+request exwm--connection
-        (make-instance 'xcb:ewmh:set-_NET_WORKAREA
-                       :window exwm--root :data workareas)))
   (xcb:flush exwm--connection))
 
 (defvar exwm-init-hook nil

--- a/exwm.el
+++ b/exwm.el
@@ -571,17 +571,17 @@
   ;; Set _NET_NUMBER_OF_DESKTOPS
   (xcb:+request exwm--connection
       (make-instance 'xcb:ewmh:set-_NET_NUMBER_OF_DESKTOPS
-                     :window exwm--root :data exwm-workspace-number))
+                     :window exwm--root :data exwm-workspace-max-count))
   ;; Set _NET_DESKTOP_VIEWPORT
   (xcb:+request exwm--connection
       (make-instance 'xcb:ewmh:set-_NET_DESKTOP_VIEWPORT
                      :window exwm--root
-                     :data (make-vector (* 2 exwm-workspace-number) 0)))
+                     :data (make-vector (* 2 exwm-workspace-max-count) 0)))
   ;; Set _NET_WORKAREA (with minibuffer and bottom mode-line excluded)
   (let* ((workareas
           (vector 0 0 (x-display-pixel-width) (x-display-pixel-height)))
          (workareas (mapconcat (lambda (i) workareas)
-                               (make-list exwm-workspace-number 0) [])))
+                               (make-list exwm-workspace-max-count 0) [])))
     (xcb:+request exwm--connection
         (make-instance 'xcb:ewmh:set-_NET_WORKAREA
                        :window exwm--root :data workareas)))

--- a/exwm.el
+++ b/exwm.el
@@ -489,7 +489,7 @@
             (when (memq xcb:Atom:_NET_WM_STATE_DEMANDS_ATTENTION props)
               (when (= action xcb:ewmh:_NET_WM_STATE_ADD)
                 (let ((idx (cl-position exwm--frame exwm-workspace--list)))
-                  (unless (= idx exwm-workspace-current-index)
+                  (unless (= idx exwm-workspace--current-index)
                     (set-frame-parameter exwm--frame 'exwm--urgency t)
                     (exwm-workspace--update-switch-history))))
               ;; xcb:ewmh:_NET_WM_STATE_REMOVE?


### PR DESCRIPTION
These changes remove the 10 workspaces limitation, and allow for a more natural workspace workflow: creating a frame creates a workspace, deleting a frame deletes the workspace.

The workspace switcher has been reworked to allow switching to any multi-digit workspaces.  (Nevertheless, at some point it should probably be extracted into a exwm-pager.el that does not rely so much on the internal, and proofs the interaction with other pagers.)

Users are able to start with a pre-defined number of workspaces by creating as many frames as they like before starting EXWM.

Right now, new workspaces are appended at the end, and windows in a deleted workspace are moved to the next one when it is destroyed.  This could be made configurable, but I think it can wait.

Please, note that #45 should be applied first, as the issues it fixes wreak havoc when manipulating workspaces.

The configuration example in the Wiki should probably be updated as well.

I have left more-or-less small commits, in case it helps review. Of course, I appreciate any comment, critique, etc.