### PR TITLE
Limit X host-based auth permissions.

### DIFF
--- a/xinitrc
+++ b/xinitrc
@@ -1,5 +1,5 @@
 # Disable access control
-xhost +
+xhost +SI:localuser:$USER
 
 # Themes, etc
 gnome-settings-daemon &


### PR DESCRIPTION
We don't need more than the currently logged in user
to have access to the X session, so don't grant X host access
to other users.