### PR TITLE
Resize minibuffer only when it's in its own frame

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -111,7 +111,7 @@ It's updated in several occasions, and only used by `exwm-input--set-focus'.")
             (exwm-input--set-focus exwm--id)
             ;; Adjust stacking orders
             (when exwm--floating-frame
-              (if (memq exwm-workspace-minibuffer-position '(top bottom))
+              (if (exwm-workspace--minibuffer-own-frame-p)
                   ;; Put this floating X window just below the minibuffer.
                   (xcb:+request exwm--connection
                       (make-instance 'xcb:ConfigureWindow

--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -203,8 +203,9 @@
         (id (frame-parameter frame 'exwm-outer-id))
         (workspace (frame-parameter frame 'exwm-workspace)))
     (with-slots (x y width height) geometry
-      (when (eq frame exwm-workspace--current)
-        (exwm-workspace--resize-minibuffer width height))
+      (when (and (eq frame exwm-workspace--current)
+                 (exwm-workspace--minibuffer-own-frame-p))
+        (exwm-workspace--resize-minibuffer-frame width height))
       (exwm-layout--resize-container id workspace x y width height)
       (xcb:flush exwm--connection))))
 
@@ -395,7 +396,7 @@ See also `exwm-layout-enlarge-window'."
   "Initialize layout module."
   ;; Auto refresh layout
   (add-hook 'window-configuration-change-hook #'exwm-layout--refresh)
-  (unless (memq exwm-workspace-minibuffer-position '(top bottom))
+  (unless (exwm-workspace--minibuffer-own-frame-p)
     ;; Refresh when minibuffer grows
     (add-hook 'minibuffer-setup-hook #'exwm-layout--on-minibuffer-setup t)
     (run-with-idle-timer 0 t #'exwm-layout--on-echo-area-change t)

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -103,8 +103,9 @@
                                          (frame-parameter frame
                                                           'exwm-workspace)
                                          x y width height)
-          (when (eq frame exwm-workspace--current)
-            (exwm-workspace--resize-minibuffer width height))
+          (when (and (eq frame exwm-workspace--current)
+                     (exwm-workspace--minibuffer-own-frame-p))
+            (exwm-workspace--resize-minibuffer-frame width height))
           (setq workareas
                 (nconc workareas (list x y width (- height
                                                     workarea-offset)))


### PR DESCRIPTION
0e4055d3392 introduced a few calls to exwm-workspace--resize-minibuffer
in various places. This function only works when the minibuffer is
displayed in its own frame but was called unconditionally in some cases.

Fix it by wrapping all calls in an appropriate conditional and add an
assertion. Also rename the function so it is clearer that it resizes a
frame, which might prevent calling it unconditionally in the future.

There seems to be another issue with the new code which I haven't been
able to track down yet: the area of the first workspace doesn't cover the whole screen
but is slightly smaller. It's only off by a few pixels though and doesn't affect all
workspaces.