### PR TITLE
Remember last buffer

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -282,11 +282,11 @@
             (if (not windows)
                 (when (eq frame exwm--frame) ;for exwm-layout-show-all-buffers
                   (exwm-layout--hide exwm--id))
-              (if (eq frame exwm--frame)
-                  (exwm-layout--show exwm--id (car windows))
-                (exwm-workspace-move-window
-                 (cl-position frame exwm-workspace--list) exwm--id))
               (let ((window (car windows)))
+                (if (eq frame exwm--frame)
+                    (exwm-layout--show exwm--id window)
+                  (exwm-workspace-move-window
+                   (cl-position frame exwm-workspace--list) exwm--id))
                 ;; Make sure this buffer is not displayed elsewhere
                 (dolist (i (get-buffer-window-list (current-buffer) 0 t))
                   (unless (eq i window)

--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -255,13 +255,13 @@
     (if (not (memq frame exwm-workspace--list))
         (if (frame-parameter frame 'exwm-outer-id)
             ;; Refresh a floating frame
-            (when (eq major-mode 'exwm-mode)
-              (let ((window (frame-first-window frame)))
-                (with-current-buffer (window-buffer window)
-                  ;; It may be a buffer waiting to be killed.
-                  (when (exwm--id->buffer exwm--id)
-                    (exwm--log "Refresh floating window #x%x" exwm--id)
-                    (exwm-layout--show exwm--id window)))))
+            (let ((window (frame-first-window frame)))
+              (with-current-buffer (window-buffer window)
+                (when (and (eq major-mode 'exwm-mode)
+                           ;; It may be a buffer waiting to be killed.
+                           (exwm--id->buffer exwm--id))
+                  (exwm--log "Refresh floating window #x%x" exwm--id)
+                  (exwm-layout--show exwm--id window))))
           ;; Other frames (e.g. terminal/graphical frame of emacsclient)
           ;; We shall bury all `exwm-mode' buffers in this case
           (setq windows (window-list frame 0)) ;exclude minibuffer

--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -240,6 +240,17 @@
       (xcb:flush exwm--connection)))
   (cl-incf exwm-layout--fullscreen-frame-count))
 
+(defun exwm-layout--other-buffer-predicate (buffer)
+  "Return non-nil when the BUFFER may be displayed in selected frame.
+
+Prevents EXWM-mode buffers already being displayed on some other window from
+being selected.
+
+Should be set as `buffer-predicate' frame parameter for all
+frames.  Used by `other-buffer'."
+  (not (and (eq 'exwm-mode (buffer-local-value 'major-mode buffer))
+            (get-buffer-window buffer t))))
+
 (defvar exwm-layout-show-all-buffers nil
   "Non-nil to allow switching to buffers on other workspaces.")
 

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -347,11 +347,7 @@ The optional FORCE option is for internal use only."
           ;; Move the X window container.
           (if (= index exwm-workspace-current-index)
               (set-window-buffer (get-buffer-window (current-buffer) t)
-                                 (or (get-buffer "*scratch*")
-                                     (progn
-                                       (set-buffer-major-mode
-                                        (get-buffer-create "*scratch*"))
-                                       (get-buffer "*scratch*"))))
+                                 (other-buffer))
             (bury-buffer)
             ;; Clear the 'exwm-selected-window' frame parameter.
             (set-frame-parameter frame 'exwm-selected-window nil))

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -235,6 +235,7 @@ The optional FORCE option is for internal use only."
 (declare-function exwm-layout--show "exwm-layout.el" (id &optional window))
 (declare-function exwm-layout--hide "exwm-layout.el" (id))
 (declare-function exwm-layout--refresh "exwm-layout.el")
+(declare-function exwm-layout--other-buffer-predicate "exwm-layout.el" (buffer))
 
 ;;;###autoload
 (defun exwm-workspace-move-window (index &optional id)
@@ -684,6 +685,9 @@ The optional FORCE option is for internal use only."
     ;; The default behavior of `display-buffer' (indirectly called by
     ;; `minibuffer-completion-help') is not correct here.
     (cl-pushnew '(exwm-workspace--display-buffer) display-buffer-alist))
+  ;; Prevent `other-buffer' from selecting already displayed EXWM buffers.
+  (modify-all-frames-parameters
+   '((buffer-predicate . exwm-layout--other-buffer-predicate)))
   ;; Configure workspaces
   (dolist (i exwm-workspace--list)
     (let ((outer-id (string-to-number (frame-parameter i 'outer-window-id)))


### PR DESCRIPTION
In contrast with regular Emacs buffers, EXWM buffers may only be shown in a single window.  Requesting an EXWM buffer to be displayed in some window requires the original window displaying it to have some other buffer displayed instead.  This change makes the most recent buffer displayed in that window be selected (with some sensible exceptions like when it is an EXWM buffer displayed elsewhere or it is an EXWM buffer that is being covered with another buffer).