### PR TITLE
set fullscreen-frame-count to 0 on exiting

### DIFF
--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -1401,6 +1401,7 @@ applied to all subsequently created X frames."
         exwm-workspace--list nil
         exwm-workspace--client nil
         exwm-workspace--minibuffer nil
+        exwm-workspace--fullscreen-frame-count 0
         default-minibuffer-frame nil)
   (remove-hook 'minibuffer-setup-hook #'exwm-workspace--on-minibuffer-setup)
   (remove-hook 'minibuffer-exit-hook #'exwm-workspace--on-minibuffer-exit)


### PR DESCRIPTION
I use Emacs as a daemon and execute `emacsclient -c` at the end of `.xsession`.
First time, everything is good.
However, if I exit the X session using `save-buffers-kill-terminal` and restart X,
then an error occurs and the X session goes down.
Enabling debug, I found this is because
in the function `exwm-workspace--post-init`, the variable `exwm-workspace--fullscreen-frame-count`
is used as a numeric value, but at the end of the function, the variable is set to `nil`
so that at the second call of the function, `wrong-type-argument` is signaled.
To fix the bug, I propose to reset `exwm-workspace--fullscreen-frame-count` to `0`
in the function `exwm-workspace--exit`.