### PR TITLE
Improve exwm-workspace-move-window behavior in specific case

### DIFF
--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -746,10 +746,9 @@ INDEX must not exceed the current number of workspaces."
                                        (frame-root-window
                                         exwm--floating-frame)))))
           ;; Move the X window container.
-          (if (eq frame exwm-workspace--current)
-              (set-window-buffer (get-buffer-window (current-buffer) t)
-                                 (other-buffer))
-            (bury-buffer)
+          (set-window-buffer (get-buffer-window (current-buffer) t)
+                             (other-buffer))
+          (unless (eq frame exwm-workspace--current)
             ;; Clear the 'exwm-selected-window' frame parameter.
             (set-frame-parameter frame 'exwm-selected-window nil))
           (exwm-layout--hide id)


### PR DESCRIPTION
This is a small change that improves the behavior of
`exwm-workspace-move-window` in the following situation:

0. `exwm-workspace-show-all-buffers` and `exwm-layout-show-all-buffers`
are `nil`*.
1. On active workspace `i`, there is X window `a` in the selected Emacs
window.
2. On workspace `j`, there is X window `b` in the selected Emacs window
on that workspace frame.
3. While workspace `i` is active, use `exwm-workspace-move-window` to
move `a` to workspace `j`.
4. Switch to workspace `j` and use `exwm-workspace-move-window` to move
`a` back to workspace `i`.

Expected behavior: X window `a` is once again shown in the selected
Emacs window on workspace `i` and X window `b` is once again shown in
the selected Emacs window on workspace `j`.

What is observed: `a` is OK but the selected Emacs window on workspace
`j` does not show `b`. However, `b` is the first candidate when doing a
`switch-to-buffer` in that Emacs window on workspace `j`.

I'm not sure if this is the correct and complete change required, but it
is working well so far.

*The expected behavior is observed with EXWM 0.10 if
`exwm-{workspace,layout}-show-all-buffers` are non-nil.