### PR TITLE
Fix EXWM buffers not being hidden on workspace switch

### DIFF
--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -544,8 +544,8 @@ for internal use only."
          (t
           (dolist (w exwm-workspace--list)
             (when (and (exwm-workspace--active-p w)
-                       (eq output-new
-                           (frame-parameter w 'exwm-randr-output)))
+                       (equal output-new
+                              (frame-parameter w 'exwm-randr-output)))
               (exwm-workspace--set-active w nil)
               (setq workspaces-to-hide (append workspaces-to-hide (list w)))))
           (exwm-workspace--set-active frame t)))
@@ -756,8 +756,8 @@ INDEX must not exceed the current number of workspaces."
           ;; Floating.
           (setq container (frame-parameter exwm--floating-frame
                                            'exwm-container))
-          (unless (eq (frame-parameter old-frame 'exwm-randr-output)
-                      (frame-parameter frame 'exwm-randr-output))
+          (unless (equal (frame-parameter old-frame 'exwm-randr-output)
+                         (frame-parameter frame 'exwm-randr-output))
             (with-slots (x y)
                 (xcb:+request-unchecked+reply exwm--connection
                     (make-instance 'xcb:GetGeometry


### PR DESCRIPTION
When I switch workspaces, EXWM buffers are not correctly hidden, but stays visible and in the way of the buffers I actually want to use. I tracked it down to the `output-{new,old}` objects being equal component wise, but not reference wise in this `cond` clause. Using the less-strict component-wise equality test of `equal` fixed it for me.

I see there are many uses of `eq` in the EXWM source in general. Maybe there are more bugs in here due to the use of too-strict equality tests with `eq`. Just a thing to consider.