### PR TITLE
Support disabling default `exwm-mode-map' bindings

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -566,7 +566,7 @@ instead."
                      ;;
                      (memq event exwm-input--global-prefix-keys)
                      (memq event exwm-input-prefix-keys)
-                     (assq event (cdr exwm-mode-map))
+                     (lookup-key exwm-mode-map (vector event))
                      (gethash event exwm-input--simulation-keys)))
         (setq mode xcb:Allow:AsyncKeyboard)
         (exwm-input--cache-event event))


### PR DESCRIPTION
This lets `(define-key exwm-mode-map (kbd "C-c") nil)` recover <key>C-c</key> for XTerm.