### PR TITLE
Consistently name helper windows

### DIFF
--- a/exwm-systemtray.el
+++ b/exwm-systemtray.el
@@ -70,7 +70,7 @@ You shall use the default value if using auto-hide minibuffer."
 
 (defvar exwm-systemtray--connection nil "The X connection.")
 
-(defvar exwm-systemtray--embedder nil "The embedder window.")
+(defvar exwm-systemtray--embedder-window nil "The embedder window.")
 
 (defvar exwm-systemtray--list nil "The icon list.")
 
@@ -112,7 +112,7 @@ You shall use the default value if using auto-hide minibuffer."
       (xcb:+request exwm-systemtray--connection
           (make-instance 'xcb:ReparentWindow
                          :window icon
-                         :parent exwm-systemtray--embedder
+                         :parent exwm-systemtray--embedder-window
                          :x 0
                          ;; Vertically centered.
                          :y (/ (- exwm-systemtray-height height*) 2)))
@@ -162,7 +162,7 @@ You shall use the default value if using auto-hide minibuffer."
                           (make-instance 'xcb:xembed:EMBEDDED-NOTIFY
                                          :window icon
                                          :time xcb:Time:CurrentTime
-                                         :embedder exwm-systemtray--embedder
+                                         :embedder exwm-systemtray--embedder-window
                                          :version 0)
                           exwm-systemtray--connection)))
       (push `(,icon . ,(make-instance 'exwm-systemtray--icon
@@ -190,7 +190,7 @@ You shall use the default value if using auto-hide minibuffer."
   "Refresh the system tray."
   ;; Make sure to redraw the embedder.
   (xcb:+request exwm-systemtray--connection
-      (make-instance 'xcb:UnmapWindow :window exwm-systemtray--embedder))
+      (make-instance 'xcb:UnmapWindow :window exwm-systemtray--embedder-window))
   (let ((x exwm-systemtray-icon-gap)
         map)
     (dolist (pair exwm-systemtray--list)
@@ -207,14 +207,14 @@ You shall use the default value if using auto-hide minibuffer."
                          exwm-workspace-current-index)))
       (xcb:+request exwm-systemtray--connection
           (make-instance 'xcb:ConfigureWindow
-                         :window exwm-systemtray--embedder
+                         :window exwm-systemtray--embedder-window
                          :value-mask (logior xcb:ConfigWindow:X
                                              xcb:ConfigWindow:Width)
                          :x (- (aref workarea 2) x)
                          :width x)))
     (when map
       (xcb:+request exwm-systemtray--connection
-          (make-instance 'xcb:MapWindow :window exwm-systemtray--embedder))))
+          (make-instance 'xcb:MapWindow :window exwm-systemtray--embedder-window))))
   (xcb:flush exwm-systemtray--connection))
 
 (defun exwm-systemtray--on-DestroyNotify (data _synthetic)
@@ -230,7 +230,7 @@ You shall use the default value if using auto-hide minibuffer."
   (let ((obj (make-instance 'xcb:ReparentNotify)))
     (xcb:unmarshal obj data)
     (with-slots (window parent) obj
-      (when (and (/= parent exwm-systemtray--embedder)
+      (when (and (/= parent exwm-systemtray--embedder-window)
                  (assoc window exwm-systemtray--list))
         (exwm-systemtray--unembed window)))))
 
@@ -325,7 +325,7 @@ You shall use the default value if using auto-hide minibuffer."
   (unless (exwm-workspace--minibuffer-own-frame-p)
     (xcb:+request exwm-systemtray--connection
         (make-instance 'xcb:ReparentWindow
-                       :window exwm-systemtray--embedder
+                       :window exwm-systemtray--embedder-window
                        :parent (string-to-number
                                 (frame-parameter exwm-workspace--current
                                                  'window-id))
@@ -339,7 +339,7 @@ You shall use the default value if using auto-hide minibuffer."
   (unless (exwm-workspace--minibuffer-own-frame-p)
     (xcb:+request exwm-systemtray--connection
         (make-instance 'xcb:ConfigureWindow
-                       :window exwm-systemtray--embedder
+                       :window exwm-systemtray--embedder-window
                        :value-mask xcb:ConfigWindow:Y
                        :y (- (frame-pixel-height exwm-workspace--current)
                              exwm-systemtray-height))))
@@ -353,7 +353,7 @@ You shall use the default value if using auto-hide minibuffer."
   (cl-assert (not exwm-systemtray--connection))
   (cl-assert (not exwm-systemtray--list))
   (cl-assert (not exwm-systemtray--selection-owner-window))
-  (cl-assert (not exwm-systemtray--embedder))
+  (cl-assert (not exwm-systemtray--embedder-window))
   (unless exwm-systemtray-height
     (setq exwm-systemtray-height (max exwm-systemtray--icon-min-size
                                       (line-pixel-height))))
@@ -414,7 +414,7 @@ You shall use the default value if using auto-hide minibuffer."
     ;; Set _NET_WM_NAME.
     (xcb:+request exwm-systemtray--connection
         (make-instance 'xcb:ewmh:set-_NET_WM_NAME
-                       :window id :data "EXWM system tray selection owner"))
+                       :window id :data "EXWM: exwm-systemtray--selection-owner-window"))
     ;; Set the _NET_SYSTEM_TRAY_ORIENTATION property.
     (xcb:+request exwm-systemtray--connection
         (make-instance 'xcb:xembed:set-_NET_SYSTEM_TRAY_ORIENTATION
@@ -423,7 +423,7 @@ You shall use the default value if using auto-hide minibuffer."
   ;; Create the embedder.
   (let ((id (xcb:generate-id exwm-systemtray--connection))
         frame parent depth y)
-    (setq exwm-systemtray--embedder id)
+    (setq exwm-systemtray--embedder-window id)
     (if (exwm-workspace--minibuffer-own-frame-p)
         (setq frame exwm-workspace--minibuffer
               y (if (>= (line-pixel-height) exwm-systemtray-height)
@@ -460,7 +460,7 @@ You shall use the default value if using auto-hide minibuffer."
     ;; Set _NET_WM_NAME.
     (xcb:+request exwm-systemtray--connection
         (make-instance 'xcb:ewmh:set-_NET_WM_NAME
-                       :window id :data "EXWM system tray embedder")))
+                       :window id :data "EXWM: exwm-systemtray--embedder-window")))
   (xcb:flush exwm-systemtray--connection)
   ;; Attach event listeners.
   (xcb:+event exwm-systemtray--connection 'xcb:DestroyNotify
@@ -494,10 +494,10 @@ You shall use the default value if using auto-hide minibuffer."
     ;; parent of the embedder).
     (xcb:+request exwm-systemtray--connection
         (make-instance 'xcb:UnmapWindow
-                       :window exwm-systemtray--embedder))
+                       :window exwm-systemtray--embedder-window))
     (xcb:+request exwm-systemtray--connection
         (make-instance 'xcb:ReparentWindow
-                       :window exwm-systemtray--embedder
+                       :window exwm-systemtray--embedder-window
                        :parent exwm--root
                        :x 0
                        :y 0))
@@ -505,7 +505,7 @@ You shall use the default value if using auto-hide minibuffer."
     (setq exwm-systemtray--connection nil
           exwm-systemtray--list nil
           exwm-systemtray--selection-owner-window nil
-          exwm-systemtray--embedder nil)
+          exwm-systemtray--embedder-window nil)
     (remove-hook 'exwm-workspace-switch-hook
                  #'exwm-systemtray--on-workspace-switch)
     (remove-hook 'exwm-workspace--update-workareas-hook

--- a/exwm.el
+++ b/exwm.el
@@ -665,15 +665,15 @@
                        :visual 0
                        :value-mask xcb:CW:OverrideRedirect
                        :override-redirect 1))
+    ;; Set _NET_WM_NAME
+    (xcb:+request exwm--connection
+        (make-instance 'xcb:ewmh:set-_NET_WM_NAME
+                       :window new-id :data "EXWM: exwm--guide-window"))
     (dolist (i (list exwm--root new-id))
       ;; Set _NET_SUPPORTING_WM_CHECK
       (xcb:+request exwm--connection
           (make-instance 'xcb:ewmh:set-_NET_SUPPORTING_WM_CHECK
-                         :window i :data new-id))
-      ;; Set _NET_WM_NAME
-      (xcb:+request exwm--connection
-          (make-instance 'xcb:ewmh:set-_NET_WM_NAME
-                         :window i :data "EXWM"))))
+                         :window i :data new-id))))
   ;; Set _NET_DESKTOP_VIEWPORT (we don't support large desktop).
   (xcb:+request exwm--connection
       (make-instance 'xcb:ewmh:set-_NET_DESKTOP_VIEWPORT
@@ -712,7 +712,7 @@ manager.  If t, replace it, if nil, abort and ask the user if `ask'."
                          :override-redirect 0))
       (xcb:+request exwm--connection
           (make-instance 'xcb:ewmh:set-_NET_WM_NAME
-                         :window new-owner :data "EXWM selection owner"))
+                         :window new-owner :data "EXWM: exwm--wmsn-window"))
       (xcb:+request-checked+request-check exwm--connection
           (make-instance 'xcb:SetSelectionOwner
                          :selection xcb:Atom:WM_S0


### PR DESCRIPTION
* exwm.el (exwm--init-icccm-ewmh): Avoid naming the root window.
(exwm--wmsn-acquire): Use the symbol name in the window name.
* exwm-systemtray.el (exwm-systemtray--embedder-window): Rename
`exwm-systemtray--embedder' consistency.
(exwm-systemtray--init):  Use symbol names in the window name.

Using the symbol name helps relate the output of `xwininfo -root -tree` with the code.

Let me know whether the change interest you, or wether you prefer other convention.