### PR TITLE
Bugfix for cursor warping

### DIFF
--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -612,7 +612,7 @@ for internal use only."
         (when (or (< win-x 0)
                   (< win-y 0)
                   (> win-x (frame-pixel-width frame))
-                  (> win-y (frame-pixel-height)))
+                  (> win-y (frame-pixel-height frame)))
           (xcb:+request exwm--connection
               (make-instance 'xcb:WarpPointer
                              :src-window xcb:Window:None

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -609,7 +609,9 @@ for internal use only."
               (make-instance 'xcb:QueryPointer
                              :window (frame-parameter frame
                                                       'exwm-outer-id)))
-        (when (or (> win-x (frame-pixel-width frame))
+        (when (or (< win-x 0)
+                  (< win-y 0)
+                  (> win-x (frame-pixel-width frame))
                   (> win-y (frame-pixel-height)))
           (xcb:+request exwm--connection
               (make-instance 'xcb:WarpPointer


### PR DESCRIPTION
When I move to a workspace to the right, the warping doesn't occur because the `win-x` is negative.  This seems to fix the issue.

Also explicitly specifies the frame for `(frame-pixel-height)`, though `frame` is `(selected-frame)` anyway, so this appears to have no functional consequences.