### PR TITLE
Handle mouse events in line mode

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -158,9 +158,7 @@ least SECS seconds later."
 (defvar-local exwm--mode-line-format nil) ;save mode-line-format
 (defvar-local exwm--floating-frame-position nil) ;set when hidden.
 (defvar-local exwm--fixed-size nil)              ;fixed size
-(defvar-local exwm--keyboard-grabbed nil)        ;Keyboard grabbed.
-(defvar-local exwm--on-KeyPress         ;KeyPress event handler
-  #'exwm-input--on-KeyPress-line-mode)
+(defvar-local exwm--input-mode 'line-mode)       ;Keyboard grabbed.
 ;; Properties
 (defvar-local exwm--desktop nil "_NET_WM_DESKTOP.")
 (defvar-local exwm-window-type nil "_NET_WM_WINDOW_TYPE.")
@@ -252,7 +250,7 @@ least SECS seconds later."
     "*Keyboard*"
     "---"
     ["Toggle keyboard mode" exwm-input-toggle-keyboard]
-    ["Send key" exwm-input-send-next-key exwm--keyboard-grabbed]
+    ["Send key" exwm-input-send-next-key (eq exwm--input-mode 'line-mode)]
     ;; This is merely a reference.
     ("Send simulation key" :filter
      (lambda (&rest _args)

--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -45,6 +45,7 @@
 (defvar exwm-layout--timer nil "Timer used to track echo area changes.")
 
 (defvar exwm-workspace--current)
+(declare-function exwm-input--current-input-mode "exwm-input.el")
 (declare-function exwm-input--release-keyboard "exwm-input.el")
 (declare-function exwm-input--grab-keyboard "exwm-input.el")
 (declare-function exwm-input-grab-keyboard "exwm-input.el")
@@ -199,7 +200,7 @@
         (make-instance 'xcb:ewmh:set-_NET_WM_STATE :window exwm--id :data []))
     (xcb:flush exwm--connection)
     (set-window-dedicated-p (get-buffer-window) nil)
-    (when exwm--keyboard-grabbed
+    (when (eq 'line-mode (exwm-input--current-input-mode))
       (exwm-input--grab-keyboard exwm--id))))
 
 ;;;###autoload


### PR DESCRIPTION
* exwm-input.el (exwm-input--forward-event-to-emacs-p): Predicate
checking whether an event should be forwarded to Emacs.
(exwm-input--on-KeyPress-line-mode): Use it.
* exwm-input.el (exwm-input--cache-event): Protect against
translations swallow the event.
* exwm-input.el (exwm-input--on-ButtonPress): Forward bound mouse
events to Emacs when in line-mode.

Could help with #250.

@ch11ng, do you think this is a good approach? 