### PR TITLE
Retain echo area until input when a message is being displayed

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -137,6 +137,9 @@ defined in `exwm-mode-map' here."
 (defvar exwm-input--update-focus-window nil "The (Emacs) window to be focused.
 This value should always be overwritten.")
 
+(defvar exwm-input--event-hook nil
+  "Hook to run when EXWM receives an event.")
+
 (defvar exwm-workspace--current)
 (declare-function exwm-floating--do-moveresize "exwm-floating.el"
                   (data _synthetic))
@@ -418,7 +421,8 @@ ARGS are additional arguments to CALLBACK."
                     (setq mode (exwm-input--on-ButtonPress-char-mode)))))))))
     (xcb:+request exwm--connection
         (make-instance 'xcb:AllowEvents :mode mode :time xcb:Time:CurrentTime))
-    (xcb:flush exwm--connection)))
+    (xcb:flush exwm--connection))
+  (run-hooks 'exwm-input--event-hook))
 
 (defun exwm-input--on-KeyPress (data _synthetic)
   "Handle KeyPress event."
@@ -432,7 +436,8 @@ ARGS are additional arguments to CALLBACK."
            (exwm-input--on-KeyPress-line-mode obj data))
           (char-mode
            (exwm-input--on-KeyPress-char-mode obj data)))
-      (exwm-input--on-KeyPress-char-mode obj))))
+      (exwm-input--on-KeyPress-char-mode obj)))
+  (run-hooks 'exwm-input--event-hook))
 
 (defun exwm-input--on-CreateNotify (data _synthetic)
   "Handle CreateNotify events."

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -128,6 +128,7 @@ Please manually run the hook `exwm-workspace-list-change-hook' afterwards.")
 (defvar exwm-workspace--workareas nil "Workareas (struts excluded).")
 
 (defvar exwm-input--during-command)
+(defvar exwm-input--event-hook)
 (defvar exwm-layout-show-all-buffers)
 (defvar exwm-manage--desktop)
 (declare-function exwm-input--on-buffer-list-update "exwm-input.el" ())
@@ -1584,6 +1585,9 @@ applied to all subsequently created X frames."
   (add-hook 'after-make-frame-functions
             #'exwm-workspace--on-after-make-frame)
   (add-hook 'delete-frame-functions #'exwm-workspace--on-delete-frame)
+  (when (exwm-workspace--minibuffer-own-frame-p)
+    (add-hook 'exwm-input--event-hook
+              #'exwm-workspace--on-echo-area-clear))
   ;; Switch to the first workspace
   (exwm-workspace-switch 0 t)
   ;; Prevent frame parameters introduced by this module from being
@@ -1604,6 +1608,9 @@ applied to all subsequently created X frames."
                #'exwm-workspace--on-after-make-frame)
   (remove-hook 'delete-frame-functions
                #'exwm-workspace--on-delete-frame)
+  (when (exwm-workspace--minibuffer-own-frame-p)
+    (remove-hook 'exwm-input--event-hook
+                 #'exwm-workspace--on-echo-area-clear))
   ;; Hide & reparent out all frames (save-set can't be used here since
   ;; X windows will be re-mapped).
   (setq exwm-workspace--current nil)

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -1203,7 +1203,18 @@ Please check `exwm-workspace--minibuffer-own-frame-p' first."
                 input-method-use-echo-area)
       (setq exwm-workspace--display-echo-area-timer
             (run-with-timer exwm-workspace-display-echo-area-timeout nil
-                            #'exwm-workspace--on-echo-area-clear)))))
+                            #'exwm-workspace--echo-area-maybe-clear)))))
+
+(defun exwm-workspace--echo-area-maybe-clear ()
+  "Eventually clear the echo area container."
+  (exwm--log)
+  (if (not (current-message))
+      (exwm-workspace--on-echo-area-clear)
+    ;; Reschedule.
+    (cancel-timer exwm-workspace--display-echo-area-timer)
+    (setq exwm-workspace--display-echo-area-timer
+          (run-with-timer exwm-workspace-display-echo-area-timeout nil
+                          #'exwm-workspace--echo-area-maybe-clear))))
 
 (defun exwm-workspace--on-echo-area-clear ()
   "Run in echo-area-clear-hook to hide echo area container."


### PR DESCRIPTION
Implements feature request in #497.

Ideally, this would let `ISearch` and `eldoc` to work normally with the detached minibuffer.

This is a work in progress.