### PR TITLE
Cleanup simulation key config issues

### DIFF
--- a/exwm-config.el
+++ b/exwm-config.el
@@ -31,7 +31,8 @@
 (defun exwm-config-default ()
   "Default configuration of EXWM."
   ;; Set the initial workspace number.
-  (setq exwm-workspace-number 4)
+  (unless (get 'exwm-workspace-number 'saved-value)
+    (setq exwm-workspace-number 4)
   ;; Make class name the buffer name
   (add-hook 'exwm-update-class-hook
             (lambda ()
@@ -51,6 +52,19 @@
                       (lambda (command)
                         (interactive (list (read-shell-command "$ ")))
                         (start-process-shell-command command nil command)))
+  ;; Line-editing shortcuts
+  (unless (get 'exwm-input-simulation-keys 'saved-value)
+    (setq exwm-input-simulation-keys
+          '(([?\C-b] . [left])
+            ([?\C-f] . [right])
+            ([?\C-p] . [up])
+            ([?\C-n] . [down])
+            ([?\C-a] . [home])
+            ([?\C-e] . [end])
+            ([?\M-v] . [prior])
+            ([?\C-v] . [next])
+            ([?\C-d] . [delete])
+            ([?\C-k] . [S-end delete]))))
   ;; Enable EXWM
   (exwm-enable)
   ;; Configure Ido

--- a/exwm-config.el
+++ b/exwm-config.el
@@ -51,18 +51,6 @@
                       (lambda (command)
                         (interactive (list (read-shell-command "$ ")))
                         (start-process-shell-command command nil command)))
-  ;; Line-editing shortcuts
-  (setq exwm-input-simulation-keys
-        '(([?\C-b] . [left])
-          ([?\C-f] . [right])
-          ([?\C-p] . [up])
-          ([?\C-n] . [down])
-          ([?\C-a] . [home])
-          ([?\C-e] . [end])
-          ([?\M-v] . [prior])
-          ([?\C-v] . [next])
-          ([?\C-d] . [delete])
-          ([?\C-k] . [S-end delete])))
   ;; Enable EXWM
   (exwm-enable)
   ;; Configure Ido

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -897,7 +897,17 @@ multiple keys."
   (declare (obsolete nil "26"))
   (exwm-input--set-simulation-keys simulation-keys))
 
-(defcustom exwm-input-simulation-keys nil
+(defcustom exwm-input-simulation-keys
+  '(([?\C-b] . [left])
+    ([?\C-f] . [right])
+    ([?\C-p] . [up])
+    ([?\C-n] . [down])
+    ([?\C-a] . [home])
+    ([?\C-e] . [end])
+    ([?\M-v] . [prior])
+    ([?\C-v] . [next])
+    ([?\C-d] . [delete])
+    ([?\C-k] . [S-end delete]))
   "Simulation keys.
 
 It is an alist of the form (original-key . simulated-key), where both
@@ -915,8 +925,9 @@ Notes:
 * The predefined examples in the Customize interface are not guaranteed to
   work for all applications.  This can be tweaked on a per application basis
   with `exwm-input-set-local-simulation-keys'."
-  :type '(alist :key-type (choice (key-sequence :tag "Original"))
-                :value-type (choice (key-sequence :tag "Move left" [left])
+  :type '(alist :key-type (key-sequence :tag "Original")
+                :value-type (choice (key-sequence :tag "User-defined")
+                                    (key-sequence :tag "Move left" [left])
                                     (key-sequence :tag "Move right" [right])
                                     (key-sequence :tag "Move up" [up])
                                     (key-sequence :tag "Move down" [down])
@@ -928,8 +939,7 @@ Notes:
                                     (key-sequence :tag "Paste" [C-v])
                                     (key-sequence :tag "Delete" [delete])
                                     (key-sequence :tag "Delete to EOL"
-                                                  [S-end delete])
-                                    (key-sequence :tag "User-defined")))
+                                                  [S-end delete])))
   :set (lambda (symbol value)
          (set symbol value)
          (exwm-input--set-simulation-keys value)))


### PR DESCRIPTION
 - Rearrange defcustom for `exwm-input-simulation-keys`:
   - Original key only has one option, so probably shouldn’t be a
     `choice` type.
   - Move the "User-defined" key value to the top, since that’s the
     one someone is most likely to want.
   - Set a default value for the variable.
 - Remove the setting of `exwm-input-simulation-keys` from
   `exwm-config-default`.  When this value is set, it discards the
    simulation keys the user set up in customize.