### PR TITLE
Surely grab keyboard when answering about killing unresponsive app #255

### DIFF
--- a/exwm-manage.el
+++ b/exwm-manage.el
@@ -533,9 +533,11 @@ manager is shutting down."
                                  exwm--connection)))
       (xcb:flush exwm--connection)
       (with-timeout (exwm-manage-ping-timeout
-                     (if (y-or-n-p (format "'%s' is not responding.  \
+                     (if (progn
+                           (exwm-input--grab-keyboard)
+                           (y-or-n-p (format "'%s' is not responding.  \
 Would you like to kill it? "
-                                              (buffer-name)))
+                                             (buffer-name))))
                          (progn (exwm-manage--kill-client id)
                                 ;; Kill the unresponsive X window and
                                 ;; wait for DestroyNotify event.


### PR DESCRIPTION
When an app is unresponsive, killing the buffer causes yes-or-no question in
minibuffer. But if the buffer is in char mode, we cannot answer the question.
Changing mode to line mode is also blocked. This is probably because y-or-n-p
catches the mode-transition key. So, first change mode to line mode and question
yes-or-no.