### PR TITLE
Added option to have a key to exit exwm-input-send-next-key

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -864,9 +864,14 @@ If END-KEY is non-nil, stop sending keys if that key is pressed"
 	(let ((exwm-input-line-mode-passthrough t))
 	  (catch 'break
 	    (while t
-	      (setq key (read-key (format "Send key: %s (%d/%d)"
-					  (key-description keys)
-					  (1+ i) times)))
+	      (setq key (read-key
+			 (format "Send key: %s (%d/%d) %s"
+				 (key-description keys)
+				 (1+ i) times
+				 (if end-key
+				     (concat "To exit, press: "
+					     (key-description (list end-key)))
+				   ""))))
 	      (unless (listp key) (throw 'break nil)))))
 	(setq keys (vconcat keys (vector key)))
 	(if (and end-key (eq key end-key))


### PR DESCRIPTION
I'm using this function to send keys to a link hinter until a link is followed using the enter key. But since the link hinter has 1-3 characters per hint depending on how close up in the browser the link is I can't just send 3 or 1 keypresses all the time. This change allows me to have the function exit if enter is pressed for example