### PR TITLE
Avoid entering line-mode after exiting ivy

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -1029,7 +1029,7 @@ where both ORIGINAL-KEY and SIMULATED-KEY are key sequences."
 
 (defun exwm-input--on-pre-command ()
   "Run in `pre-command-hook'."
-  (unless (eq this-command #'exit-minibuffer)
+  (unless (memq this-command '(exit-minibuffer ivy-done))
     (setq exwm-input--during-command t)))
 
 (defun exwm-input--on-post-command ()


### PR DESCRIPTION
Extension of 02b1be7160051610a542764ec392e3a50f23fb5a.

Without this, the following command will swallow one key after it exits.

```bash
emacsclient -e '(ivy-read "prompt: " (list "foo" "bar"))'
```