### PR TITLE
Fix misdirected key presses after aborting emacsclient

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -961,7 +961,7 @@ Notes:
          (set symbol value)
          (exwm-input--set-simulation-keys value)))
 
-(defcustom exwm-input-pre-post-command-blacklist '(exit-minibuffer)
+(defcustom exwm-input-pre-post-command-blacklist '(exit-minibuffer minibuffer-keyboard-quit)
   "Commands impossible to detect with `post-command-hook'."
   :type '(repeat function))
 

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -441,18 +441,19 @@ ARGS are additional arguments to CALLBACK."
 
 (defun exwm-input--on-KeyPress (data _synthetic)
   "Handle KeyPress event."
-  (let ((obj (make-instance 'xcb:KeyPress)))
-    (xcb:unmarshal obj data)
-    (exwm--log "major-mode=%s buffer=%s"
-               major-mode (buffer-name (current-buffer)))
-    (if (derived-mode-p 'exwm-mode)
-        (cl-case exwm--input-mode
-          (line-mode
-           (exwm-input--on-KeyPress-line-mode obj data))
-          (char-mode
-           (exwm-input--on-KeyPress-char-mode obj data)))
-      (exwm-input--on-KeyPress-char-mode obj)))
-  (run-hooks 'exwm-input--event-hook))
+  (with-current-buffer (window-buffer (selected-window))
+    (let ((obj (make-instance 'xcb:KeyPress)))
+      (xcb:unmarshal obj data)
+      (exwm--log "major-mode=%s buffer=%s"
+                 major-mode (buffer-name (current-buffer)))
+      (if (derived-mode-p 'exwm-mode)
+          (cl-case exwm--input-mode
+            (line-mode
+             (exwm-input--on-KeyPress-line-mode obj data))
+            (char-mode
+             (exwm-input--on-KeyPress-char-mode obj data)))
+        (exwm-input--on-KeyPress-char-mode obj)))
+    (run-hooks 'exwm-input--event-hook)))
 
 (defun exwm-input--on-CreateNotify (data _synthetic)
   "Handle CreateNotify events."


### PR DESCRIPTION
To reproduce:

1. Run `emacsclient -e '(read-string "foobar")'` in a terminal (X, not emacs).
2. At the prompt, hit C-g.
3. Hit any key.

The key will be directed to emacs.

The issue is that emacs sits for 5 seconds after returning an error to emacsclient. Unfortunately, it sits while the current buffer is set to " *server*". This causes emacs to mis-detect the buffer's mode.

This fix:

1. Always sets the current buffer to the current buffer of the selected window when handling key press events.
2. Adds minibuffer-keyboard-quit to the post/pre command blacklist.