### PR TITLE
Fix window manager name

### DIFF
--- a/exwm.el
+++ b/exwm.el
@@ -730,10 +730,11 @@
                        :visual 0
                        :value-mask xcb:CW:OverrideRedirect
                        :override-redirect 1))
-    ;; Set _NET_WM_NAME
+    ;; Set _NET_WM_NAME.  Must be set to the name of the window manager, as
+    ;; required by wm-spec.
     (xcb:+request exwm--connection
         (make-instance 'xcb:ewmh:set-_NET_WM_NAME
-                       :window new-id :data "EXWM: exwm--guide-window"))
+                       :window new-id :data "EXWM"))
     (dolist (i (list exwm--root new-id))
       ;; Set _NET_SUPPORTING_WM_CHECK
       (xcb:+request exwm--connection


### PR DESCRIPTION
	* exwm.el (exwm--init-icccm-ewmh): Correct _NET_WM_NAME to the
	name of the window manager on the _NET_SUPPORTING_WM_CHECK.

> _NET_SUPPORTING_WM_CHECK
> 
> _NET_SUPPORTING_WM_CHECK, WINDOW/32
> 
> The Window Manager MUST set this property on the root window to be the ID of a child window created by himself, to indicate that a compliant window manager is active. The child window MUST also have the _NET_SUPPORTING_WM_CHECK property set to the ID of the child window. The child window MUST also have the _NET_WM_NAME property set to the name of the Window Manager.
> [...]

This aspect was wrong in 29f2289a750c9cf8f0d5cd968d306ee953a7bc0d.