### PR TITLE
Improve detection of focus changes

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -117,9 +117,6 @@ defined in `exwm-mode-map' here."
 
 (defvar exwm-input--simulation-keys nil "Simulation keys in line-mode.")
 
-(defvar exwm-input--skip-buffer-list-update nil
-  "Skip the upcoming 'buffer-list-update'.")
-
 (defvar exwm-input--temp-line-mode nil
   "Non-nil indicates it's in temporary line-mode for char-mode.")
 
@@ -311,7 +308,6 @@ ARGS are additional arguments to CALLBACK."
   (let* ((win (selected-window))
          (buf (window-buffer win)))
     (when (and (not (exwm-workspace--client-p))
-             (not exwm-input--skip-buffer-list-update)
                (not (and (eq exwm-input--update-focus-window win)
                          (eq exwm-input--update-focus-window-buffer buf))))
       (exwm--log "selected-window=%S current-buffer=%S" win buf)

--- a/exwm-manage.el
+++ b/exwm-manage.el
@@ -151,7 +151,6 @@ want to match against EXWM internal variables such as `exwm-title',
 (defvar exwm-manage--ping-lock nil
   "Non-nil indicates EXWM is pinging a window.")
 
-(defvar exwm-input--skip-buffer-list-update)
 (defvar exwm-input-prefix-keys)
 (defvar exwm-workspace--current)
 (defvar exwm-workspace--id-struts-alist)
@@ -263,8 +262,7 @@ want to match against EXWM internal variables such as `exwm-title',
         (make-instance 'xcb:ChangeSaveSet
                        :mode xcb:SetMode:Insert
                        :window id))
-    (with-current-buffer (let ((exwm-input--skip-buffer-list-update t))
-                           (generate-new-buffer "*EXWM*"))
+    (with-current-buffer (generate-new-buffer "*EXWM*")
       ;; Keep the oldest X window first.
       (setq exwm--id-buffer-alist
             (nconc exwm--id-buffer-alist `((,id . ,(current-buffer)))))
@@ -349,8 +347,7 @@ want to match against EXWM internal variables such as `exwm-title',
                              :stack-mode xcb:StackMode:Below)))
         (xcb:flush exwm--connection)
         (setq exwm--id-buffer-alist (assq-delete-all id exwm--id-buffer-alist))
-        (let ((kill-buffer-query-functions nil)
-              (exwm-input--skip-buffer-list-update t))
+        (let ((kill-buffer-query-functions nil))
           (kill-buffer (current-buffer)))
         (throw 'return 'ignored))
       (let ((index (plist-get exwm--configurations 'workspace)))


### PR DESCRIPTION
	* exwm-input.el: (exwm-input--on-buffer-list-update): Keep track
	of last selected window and buffer, update focus only when those
	change.
	(exwm-input--update-focus-defer): Add commentary.
	(exwm-input--buffer-list-update-last-selected-window)
	(exwm-input--buffer-list-update-last-selected-buffer): Add
	variables.
	(exwm-input--skip-buffer-list-update): Remove variable.
	(exwm-input--on-buffer-list-update): Stop checking
	`exwm-input--skip-buffer-list-update'; it's no longer needed when
	keeping track selected window and buffer.

	* exwm-manage.el (exwm-manage--manage-window): Remove binding of
	`exwm-input--skip-buffer-list-update'.

This should limit substantially the number of `on-buffer-list-updates` we react to.  Especially, it should ignore all `with-temp-buffer`, as those don't select a different window (note that we use `(window-buffer (selected-window))` and not `(current-buffer)`).

A further improvement could be to check that the selected window belongs to an EXWM-managed frame (workspace, floating, minibuffer(?)).