### PR TITLE
Use a hash table to cache result of ‘exwm-workspace--client-p’

### DIFF
--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -165,10 +165,19 @@ NIL if FRAME is not a workspace"
   "Return t if FRAME is a workspace."
   (memq frame exwm-workspace--list))
 
+(defvar exwm--client-p-hash-table
+  (make-hash-table :test 'eq :weakness 'key))
+
 (defsubst exwm-workspace--client-p (&optional frame)
   "Return non-nil if FRAME is an emacsclient frame."
-  (or (frame-parameter frame 'client)
-      (not (display-graphic-p frame))))
+  (let* ((frame (or frame (selected-frame)))
+         (cached-value (gethash frame exwm--client-p-hash-table 'absent)))
+    (if (eq cached-value 'absent)
+        (puthash frame
+                 (or (frame-parameter frame 'client)
+                     (not (display-graphic-p frame)))
+                 exwm--client-p-hash-table)
+        cached-value)))
 
 (defvar exwm-workspace--switch-map nil
   "Keymap used for interactively selecting workspace.")

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -1469,7 +1469,8 @@ the next workspace."
       ;; care of converting a workspace into a regular unmanaged frame.
       (let ((exwm-workspace--create-silently t))
         (make-frame)))
-    (exwm-workspace--remove-frame-as-workspace frame))))
+    (exwm-workspace--remove-frame-as-workspace frame)
+    (remhash frame exwm--client-p-hash-table))))
 
 (defun exwm-workspace--on-after-make-frame (frame)
   "Hook run upon `make-frame' that configures FRAME as a workspace."

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -165,18 +165,20 @@ NIL if FRAME is not a workspace"
   "Return t if FRAME is a workspace."
   (memq frame exwm-workspace--list))
 
-(defvar exwm--client-p-hash-table
-  (make-hash-table :test 'eq :weakness 'key))
+(defvar exwm-workspace--client-p-hash-table
+  (make-hash-table :test 'eq :weakness 'key)
+  "Used to cache the results of calling ‘exwm-workspace--client-p’.")
 
 (defsubst exwm-workspace--client-p (&optional frame)
   "Return non-nil if FRAME is an emacsclient frame."
   (let* ((frame (or frame (selected-frame)))
-         (cached-value (gethash frame exwm--client-p-hash-table 'absent)))
+         (cached-value
+          (gethash frame exwm-workspace--client-p-hash-table 'absent)))
     (if (eq cached-value 'absent)
         (puthash frame
                  (or (frame-parameter frame 'client)
                      (not (display-graphic-p frame)))
-                 exwm--client-p-hash-table)
+                 exwm-workspace--client-p-hash-table)
         cached-value)))
 
 (defvar exwm-workspace--switch-map nil

--- a/exwm-xim.el
+++ b/exwm-xim.el
@@ -161,6 +161,10 @@ C,no"
 (defvar exwm-xim--_XIM_PROTOCOL nil)
 (defvar exwm-xim--_XIM_XCONNECT nil)
 
+(defvar exwm-xim-buffer-p nil
+  "Whether current buffer is used by exwm-xim.")
+(make-variable-buffer-local 'exwm-xim-buffer-p)
+
 (defun exwm-xim--on-SelectionRequest (data _synthetic)
   "Handle SelectionRequest events on IMS window.
 
@@ -585,6 +589,9 @@ The actual XIM request is in client message data or a property."
           (exwm-input--grab-keyboard))
         (unwind-protect
             (with-temp-buffer
+              ;; This variable is used to test whether exwm-xim is enabled.
+              ;; Used by e.g. pyim-probe.
+              (setq-local exwm-xim-buffer-p t)
               ;; Always show key strokes.
               (let ((input-method-use-echo-area t)
                     (exwm-input-line-mode-passthrough t))


### PR DESCRIPTION
Hi there,
I've been doing some CPU and memory profiling of my EXWM desktop, and the ‘exwm-workspace--client-p’ function conses a surprising amount of memory.  In one benchmark where I moved point from the beginning to the end of a screenful of text without any local minor modes enabled using only ‘right-char’, this function allocated nearly 4MB of memory.  Not much in the grand scheme of things, but any allocation that can be avoided should be in order to reduce GC times, and with the implementation in this PR, the memory allocated is reduced to <85k.

Thanks,
Matt