### PR TITLE
Use a list rather than a frame property to track ‘urgent’ frames

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -348,9 +348,8 @@ One of `line-mode' or `char-mode'.")
   ;;
   (setq mode-name
         '(:eval (propertize "EXWM" 'face
-                            (when (cl-some (lambda (i)
-                                             (frame-parameter i 'exwm-urgency))
-                                           exwm-workspace--list)
+                            (when (cl-intersection exwm--urgent-frames
+                                                   exwm-workspace--list)
                               'font-lock-warning-face))))
   ;; Change major-mode is not allowed
   (add-hook 'change-major-mode-hook #'kill-buffer nil t)

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -286,8 +286,8 @@ NIL if FRAME is not a workspace"
                           (propertize
                            (apply exwm-workspace-index-map (list j))
                            'face
-                           (cond ((frame-parameter (elt exwm-workspace--list j)
-                                                   'exwm-urgency)
+                           (cond ((memq (elt exwm-workspace--list j)
+                                        exwm--urgent-frames)
                                   '(:foreground "orange"))
                                  ((aref not-empty j) '(:foreground "green"))
                                  (t nil)))))
@@ -655,7 +655,7 @@ for internal use only."
                                                 name
                                               (concat " " name)))))))
       ;; Update demands attention flag
-      (set-frame-parameter frame 'exwm-urgency nil)
+      (setq exwm--urgent-frames (delq frame exwm--urgent-frames))
       ;; Update switch workspace history
       (setq exwm-workspace--switch-history-outdated t)
       ;; Set _NET_CURRENT_DESKTOP
@@ -1686,7 +1686,7 @@ applied to all subsequently created X frames."
   ;; Prevent frame parameters introduced by this module from being
   ;; saved/restored.
   (dolist (i '(exwm-active exwm-outer-id exwm-id exwm-container exwm-geometry
-                           exwm-selected-window exwm-urgency fullscreen))
+                           exwm-selected-window fullscreen))
     (unless (assq i frameset-filter-alist)
       (push (cons i :never) frameset-filter-alist))))
 
@@ -1710,8 +1710,8 @@ applied to all subsequently created X frames."
   (setq exwm-workspace--current nil)
   (dolist (i exwm-workspace--list)
     (exwm-workspace--remove-frame-as-workspace i)
+    (setq exwm--urgent-frames (delq i exwm--urgent-frames))
     (modify-frame-parameters i '((exwm-selected-window . nil)
-                                 (exwm-urgency . nil)
                                  (exwm-outer-id . nil)
                                  (exwm-id . nil)
                                  (exwm-container . nil)

--- a/exwm.el
+++ b/exwm.el
@@ -110,6 +110,9 @@
 
 (defvar exwm--server-process nil "Process of the subordinate Emacs server.")
 
+(defvar exwm--urgent-frames nil
+  "List of X windows which are ‘demanding attention’.")
+
 (defun exwm-reset ()
   "Reset the state of the selected window (non-fullscreen, line-mode, etc)."
   (interactive)
@@ -312,8 +315,8 @@
                 (setq exwm--hints-urgency t))))
           (when (and exwm--hints-urgency
                      (not (eq exwm--frame exwm-workspace--current)))
-            (unless (frame-parameter exwm--frame 'exwm-urgency)
-              (set-frame-parameter exwm--frame 'exwm-urgency t)
+            (unless (memq exwm--frame exwm--urgent-frames)
+              (push exwm--frame exwm--urgent-frames)
               (setq exwm-workspace--switch-history-outdated t))))))))
 
 (defun exwm--update-protocols (id &optional force)
@@ -567,7 +570,7 @@
             (when (memq xcb:Atom:_NET_WM_STATE_DEMANDS_ATTENTION props)
               (when (= action xcb:ewmh:_NET_WM_STATE_ADD)
                 (unless (eq exwm--frame exwm-workspace--current)
-                  (set-frame-parameter exwm--frame 'exwm-urgency t)
+                  (push exwm--frame exwm--urgent-frames)
                   (setq exwm-workspace--switch-history-outdated t)))
               ;; xcb:ewmh:_NET_WM_STATE_REMOVE?
               ;; xcb:ewmh:_NET_WM_STATE_TOGGLE?


### PR DESCRIPTION
Following the discussion in the comments in #848 here is a PR which reduces the number of times `frame-parameter` is called.  On my setup, `exwm-urgent` was the most frequently requested parameter out of those beginning with `exwm-` (`exwm-active` is the runner up).  I think this is because it was being used in mode line refreshes.

It turns out that this frame parameter corresponds to an attribute ('hint') of windows which in other WMs would blink their icon in the dock or something along those lines to try to attract attention.  I don't care about such functionality myself and I'm sure I've never even noticed the minor visual changes EXWM makes to indicate 'urgent' windows before.  Regardless, I've switched EXWM from storing this info in a frame property to using a list, and this should mean there are far fewer calls to `frame-property` being made.  As such, no memory should be consed by code simply checking the value of this property for a given frame.  Frames which have this property set are added to a list, and membership of that list is checked with `memq`.  Simple, but it should be effective.  I haven't been using these changes for long so I can't say if it makes any noticeable difference to performance, but in theory the fewer calls to `frame-property`, the better.