### PR TITLE
Transparency and aesthetics support/ideas

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -193,6 +193,21 @@ least SECS seconds later."
               (lsh (lsh (pop rgb) -8) 8)
               (lsh (pop rgb) -8)))))
 
+(defun exwm--get-visual-depth-colormap (conn id)
+  "Get visual, depth and colormap from X window ID.
+Return a three element list with the respective results."
+  (let (ret-visual ret-depth ret-colormap)
+    (with-slots (visual colormap)
+        (xcb:+request-unchecked+reply conn
+            (make-instance 'xcb:GetWindowAttributes :window id))
+      (setq ret-visual visual)
+      (setq ret-colormap colormap))
+    (with-slots (depth)
+        (xcb:+request-unchecked+reply conn
+            (make-instance 'xcb:GetGeometry :drawable id))
+      (setq ret-depth depth))
+    (list ret-visual ret-depth ret-colormap)))
+
 ;; Internal variables
 (defvar-local exwm--id nil)               ;window ID
 (defvar-local exwm--configurations nil)   ;initial configurations.


### PR DESCRIPTION
This draft PR contains a handful of patches I made to workspace handling to
a) support emacs forks/patches which use 32-bit color depths and render with partial transparency
b) set WM_STATE on workspace frames, so compositors and the like recognize them properly
b) shrink workspace frames inward by the size of a window divider on each side

Together with the changes in https://github.com/djeis97/emacs/tree/transparency (themselves based on the wonderful alpha-background patches from https://github.com/TheVaffel/emacs) which make window dividers draw transparent, I have produced something akin to i3-gaps.

However, I'm sure there are better ways to accomplish some (if not all) of what I've done here and I'm not sure how much of this even makes sense to bring into exwm proper. If nothing else, finding a visual should probably be extended to gracefully handle the case of no 32-bit visual being available. Any thoughts/suggestions would be greatly appreciated.

![emacs_transp](https://user-images.githubusercontent.com/2872315/145726670-7eb41c7c-f7f9-40a3-9f61-8df788200e37.png)
