### PR TITLE
Create `exwm-minor-mode`

### DIFF
--- a/exwm-config.el
+++ b/exwm-config.el
@@ -73,7 +73,7 @@
             ([?\C-d] . [delete])
             ([?\C-k] . [S-end delete]))))
   ;; Enable EXWM
-  (exwm-enable)
+  (exwm-minor-mode +1)
   ;; Configure Ido
   (exwm-config-ido)
   ;; Other configurations


### PR DESCRIPTION
With this change I intend to convert EXWM into a global minor mode.

Please check out and test.

Next steps would be e.g. creating a menu for the minor mode where workspaces can be managed (at the moment the menu is only available when an EXWM-mode buffer is current).  Please discuss further ideas.