### PR TITLE
Don't assume that exwm--connection is non-nil

### DIFF
--- a/exwm-background.el
+++ b/exwm-background.el
@@ -172,19 +172,17 @@ replace it.")
 (defun exwm-background--init ()
   "Initialize background module."
   (exwm--log)
-
   (add-hook 'enable-theme-functions 'exwm-background--update)
   (add-hook 'disable-theme-functions 'exwm-background--update)
-
   (exwm-background--update))
 
 (defun exwm-background--exit ()
   "Uninitialize the background module."
   (exwm--log)
-
   (remove-hook 'enable-theme-functions 'exwm-background--update)
   (remove-hook 'disable-theme-functions 'exwm-background--update)
-  (when exwm-background--connection
+  (when (and exwm-background--connection
+             (slot-value exwm-background--connection 'connected))
     (xcb:disconnect exwm-background--connection))
   (setq exwm-background--pixmap nil
         exwm-background--connection nil

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -1215,12 +1215,13 @@ One use is to access the keymap bound to KEYS (as prefix keys) in char-mode."
   (when exwm-input--update-focus-timer
     (cancel-timer exwm-input--update-focus-timer))
   ;; Make input focus working even without a WM.
-  (xcb:+request exwm--connection
-      (make-instance 'xcb:SetInputFocus
-                     :revert-to xcb:InputFocus:PointerRoot
-                     :focus exwm--root
-                     :time xcb:Time:CurrentTime))
-  (xcb:flush exwm--connection))
+  (when exwm--connection
+    (xcb:+request exwm--connection
+        (make-instance 'xcb:SetInputFocus
+                       :revert-to xcb:InputFocus:PointerRoot
+                       :focus exwm--root
+                       :time xcb:Time:CurrentTime))
+    (xcb:flush exwm--connection)))
 
 
 

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -1215,7 +1215,7 @@ One use is to access the keymap bound to KEYS (as prefix keys) in char-mode."
   (when exwm-input--update-focus-timer
     (cancel-timer exwm-input--update-focus-timer))
   ;; Make input focus working even without a WM.
-  (when exwm--connection
+  (when (slot-value exwm--connection 'connected)
     (xcb:+request exwm--connection
         (make-instance 'xcb:SetInputFocus
                        :revert-to xcb:InputFocus:PointerRoot

--- a/exwm-systemtray.el
+++ b/exwm-systemtray.el
@@ -652,19 +652,20 @@ indicate how to support actual transparency."
   "Exit the systemtray module."
   (exwm--log)
   (when exwm-systemtray--connection
-    ;; Hide & reparent out the embedder before disconnection to prevent
-    ;; embedded icons from being reparented to an Emacs frame (which is the
-    ;; parent of the embedder).
-    (xcb:+request exwm-systemtray--connection
-        (make-instance 'xcb:UnmapWindow
-                       :window exwm-systemtray--embedder-window))
-    (xcb:+request exwm-systemtray--connection
-        (make-instance 'xcb:ReparentWindow
-                       :window exwm-systemtray--embedder-window
-                       :parent exwm--root
-                       :x 0
-                       :y 0))
-    (xcb:disconnect exwm-systemtray--connection)
+    (when (slot-value exwm-systemtray--connection 'connected)
+      ;; Hide & reparent out the embedder before disconnection to prevent
+      ;; embedded icons from being reparented to an Emacs frame (which is the
+      ;; parent of the embedder).
+      (xcb:+request exwm-systemtray--connection
+          (make-instance 'xcb:UnmapWindow
+                         :window exwm-systemtray--embedder-window))
+      (xcb:+request exwm-systemtray--connection
+          (make-instance 'xcb:ReparentWindow
+                         :window exwm-systemtray--embedder-window
+                         :parent exwm--root
+                         :x 0
+                         :y 0))
+      (xcb:disconnect exwm-systemtray--connection))
     (setq exwm-systemtray--connection nil
           exwm-systemtray--list nil
           exwm-systemtray--selection-owner-window nil

--- a/exwm-xim.el
+++ b/exwm-xim.el
@@ -754,10 +754,12 @@ Such event would be received when the client window is destroyed."
   ;; Close IMS communication connections.
   (mapc (lambda (i)
           (when (vectorp i)
-            (xcb:disconnect (elt i 0))))
+            (when (slot-value (elt i 0) 'connected)
+              (xcb:disconnect (elt i 0)))))
         exwm-xim--server-client-plist)
   ;; Close the IMS connection.
-  (unless exwm-xim--conn
+  (unless (and exwm-xim--conn
+               (slot-value exwm-xim--conn 'connected))
     (cl-return-from exwm-xim--exit))
   ;; Remove exwm-xim from XIM_SERVERS.
   (let ((reply (xcb:+request-unchecked+reply exwm-xim--conn

--- a/exwm.el
+++ b/exwm.el
@@ -907,12 +907,12 @@ manager.  If t, replace it, if nil, abort and ask the user if `ask'."
   (run-hooks 'exwm-exit-hook)
   (setq confirm-kill-emacs nil)
   ;; Exit modules.
-  (exwm-input--exit)
-  (exwm-manage--exit)
-  (exwm-workspace--exit)
-  (exwm-floating--exit)
-  (exwm-layout--exit)
   (when exwm--connection
+    (exwm-input--exit)
+    (exwm-manage--exit)
+    (exwm-workspace--exit)
+    (exwm-floating--exit)
+    (exwm-layout--exit)
     (xcb:flush exwm--connection)
     (xcb:disconnect exwm--connection))
   (setq exwm--connection nil)


### PR DESCRIPTION
`exwm-input--exit` could be called (via `exwm-exit`) from `exwm-init` in case of error when initialising EXWM. It could happen that the bit that failed when `exwm-init` is executed was the call to `xcb:connect`, hence `exwm--connection` would be nil when errors are handled (and `exwm-exit` is called).

Without this patch, in the case above, the user will see a crash as there's no method allowing a nil XCB connection object:

```
  Debugger entered--Lisp error:
  (cl-no-applicable-method xcb:-+request nil #<xcb:SetInputFocus ...
```

even worse, not even giving the chance to the `warn` call in `exwm-init`'s error handler to actually inform the user about the actual problem ("[XELB] Connection timeout", for instance).