### PR TITLE
Detect unavailable keys properly. Fixes #592.

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -514,7 +514,7 @@ ARGS are additional arguments to CALLBACK."
         keysyms keycode alt-modifier)
     (dolist (k exwm-input--global-prefix-keys)
       (setq keysyms (xcb:keysyms:event->keysyms exwm--connection k))
-      (if (not keysyms)
+      (if (or (not keysyms) (= 0 (caar keysyms)))
           (warn "Key unavailable: %s" (key-description (vector k)))
         (setq keycode (xcb:keysyms:keysym->keycode exwm--connection
                                                    (caar keysyms)))
@@ -886,7 +886,7 @@ button event."
   "Fake a key event equivalent to Emacs event EVENT."
   (let* ((keysyms (xcb:keysyms:event->keysyms exwm--connection event))
          keycode id)
-    (when (= 0 (caar keysyms))
+    (when (or (not keysyms) (= 0 (caar keysyms)))
       (user-error "[EXWM] Invalid key: %s" (single-key-description event)))
     (setq keycode (xcb:keysyms:keysym->keycode exwm--connection
                                                (caar keysyms)))


### PR DESCRIPTION
`xcb:keysyms:event->keysyms` returns `'((0 . 0))` when key is unavailable.

Using the same check as here to handle this: https://github.com/ch11ng/exwm/blob/9d035d713ee2692ea095dc6e0668ecabeb550845/exwm-input.el#L889-L890

Update: noticed that `xcb:keysyms:event->keysyms` returns `nil` when the keycode is not present in the current layout.